### PR TITLE
feat: add `shouldSkipValidation` option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ module.exports.validationPlugin = function (options) {
     return function (req, res, next) {
         var validationModel = req.route?.spec?.validation || req.route?.validation || undefined;
 
-        if (validationModel && options.shouldSkipValidation(req, res, next)) {
+        if (validationModel && !options.shouldSkipValidation(req, res, next)) {
             // validate
             var errors = self.validation.process(validationModel, req, options);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,8 @@ var defaultOptions = {
     errorsAsArray: true,
     errorHandler: false,
     forbidUndefinedVariables: false,
-    validatorModels: {}
+    validatorModels: {},
+    isValidationEnabled: () => true,
 };
 
 module.exports.validationPlugin = function (options) {
@@ -52,7 +53,7 @@ module.exports.validationPlugin = function (options) {
     return function (req, res, next) {
         var validationModel = req.route?.spec?.validation || req.route?.validation || undefined;
 
-        if (validationModel) {
+        if (validationModel && isValidationEnabled(req, res, next)) {
             // validate
             var errors = self.validation.process(validationModel, req, options);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ var defaultOptions = {
     errorHandler: false,
     forbidUndefinedVariables: false,
     validatorModels: {},
-    isValidationEnabled: () => true,
+    shouldSkipValidation: () => false,
 };
 
 module.exports.validationPlugin = function (options) {
@@ -53,7 +53,7 @@ module.exports.validationPlugin = function (options) {
     return function (req, res, next) {
         var validationModel = req.route?.spec?.validation || req.route?.validation || undefined;
 
-        if (validationModel && options.isValidationEnabled(req, res, next)) {
+        if (validationModel && options.shouldSkipValidation(req, res, next)) {
             // validate
             var errors = self.validation.process(validationModel, req, options);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ module.exports.validationPlugin = function (options) {
     return function (req, res, next) {
         var validationModel = req.route?.spec?.validation || req.route?.validation || undefined;
 
-        if (validationModel && isValidationEnabled(req, res, next)) {
+        if (validationModel && options.isValidationEnabled(req, res, next)) {
             // validate
             var errors = self.validation.process(validationModel, req, options);
 


### PR DESCRIPTION
## Description
Added the `shouldSkipValidation` option to the initialisation logic, which defaults to a function returning `false`

## Context
In the payments platform we are migrating our API from restify to fastify with a feature flag for each endpoint for redirection to its fastify version (if curious, more details about redirection logic [here](https://www.notion.so/taxfix/Migrating-payment-api-from-restify-to-fastify-b7727f4c080944cc83a0a1ce47446b3e)).

However we are still validating the request with the restify-validation plugin before redirecting to `fastify`. This change makes it possible to dynamically skip validation

## Testing
I've already tested by installing the latest commit of this branch into api-utils, and then releasing a dev version to test in our payments-api: https://github.com/taxfix/payments/pull/1157